### PR TITLE
fix Vagrantfile for slow machines with little memory

### DIFF
--- a/internalizer/VagrantFile
+++ b/internalizer/VagrantFile
@@ -14,6 +14,7 @@ Vagrant.configure("2") do |config|
     cfg.winrm.password = "vagrant"
     cfg.vm.guest = :windows
     cfg.vm.communicator = "winrm"
+	cfg.vm.boot_timeout = 420
 
     cfg.vm.hostname = "prodrepo-srv"
     cfg.windows.set_work_network = true
@@ -27,7 +28,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provider :virtualbox do |v, override|
         v.gui = true
-        v.memory = 2048
+        v.memory = 1024
         v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
         v.customize ["modifyvm", :id, "--vram", 32]
         v.customize ["modifyvm", :id, "--audio", "none"]
@@ -58,6 +59,7 @@ config.vm.define "testreposrv" do |cfg|
     cfg.winrm.password = "vagrant"
     cfg.vm.guest = :windows
     cfg.vm.communicator = "winrm"
+	cfg.vm.boot_timeout = 420
 
     cfg.vm.hostname = "testrepo-srv"
     cfg.windows.set_work_network = true
@@ -72,7 +74,7 @@ config.vm.define "testreposrv" do |cfg|
 
     cfg.vm.provider :virtualbox do |v, override|
         v.gui = true
-        v.memory = 2048
+        v.memory = 1024
         v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
         v.customize ["modifyvm", :id, "--vram", 32]
         v.customize ["modifyvm", :id, "--audio", "none"]
@@ -103,6 +105,7 @@ config.vm.define "jenkins" do |cfg|
     cfg.winrm.password = "vagrant"
     cfg.vm.guest = :windows
     cfg.vm.communicator = "winrm"
+	cfg.vm.boot_timeout = 420
 
     cfg.vm.hostname = "jenkins-srv"
     cfg.windows.set_work_network = true


### PR DESCRIPTION
machines also work quite well with fewer resources.
- 1GB ram is enough for the repo images
- ready timeout increased to 420 seconds